### PR TITLE
bugfix: Fix IBus-libhanjp adaptation

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install dependencies
-      run: sudo apt update && sudo apt install gettext libhangul-dev libibus-1.0-dev libglib2.0-dev
+      run: sudo apt update && sudo apt install gettext libhangul-dev libibus-1.0-dev libglib2.0-dev check
       
     - name: Update submodules
       run: git submodule update --init --recursive

--- a/ibus/hanjpengine.c
+++ b/ibus/hanjpengine.c
@@ -92,7 +92,7 @@ engine_init(IBusHanjpEngine *self)
     self->context = hanjp_ic_new();
     self->input_mode = HANJP_INPUT_MODE_JP;
     self->preedit = hanjp_ic_ref_preedit_string(self->context);
-    self->committed = hanjp_ic_ref_hangul_string(self->context);
+    self->committed = hanjp_ic_ref_commit_string(self->context);
     self->hangul = hanjp_ic_ref_hangul_string(self->context);
 }
 

--- a/ibus/hanjpengine.c
+++ b/ibus/hanjpengine.c
@@ -147,6 +147,9 @@ static gboolean engine_process_key_event(
         }
     }
     else if(ret < 0) {
+		text = ibus_text_new_from_static_string ("");
+		ibus_engine_update_preedit_text (engine, text, 0, FALSE);
+
         text = ibus_text_new_from_ucs4((const gunichar*)hanjp->committed->data);
         ibus_engine_commit_text(engine, text);
     }


### PR DESCRIPTION
* Main reason for the committed text turns into Hangul was following:
  it linked committed text by the wrong function. (need to call `hanjp_ic_ref_commit_string()`, but called `hanjp_ic_ref_hangul_string()`)
* Need to clear committed data to prevent duplicating previous inputs.
* Need to clear preedit in IBus when the commit text was ready to commit in IBus.